### PR TITLE
Fix predicate name lookup for brr and bra instructions.

### DIFF
--- a/qpu-tutorial/qpuasm.js
+++ b/qpu-tutorial/qpuasm.js
@@ -86,8 +86,8 @@ var cc = mkEnum([
 ]);
 
 var bcc = mkEnum([
-        ".allz", ".allnz", ".anyz", ".anynz", ".alln", ".allnn", ".anyn", ".anynn",
-        ".allc", ".allnc", ".anyc", ".anync", ".cc12", ".cc13", ".cc14", ""
+        "allz", "allnz", "anyz", "anynz", "alln", "allnn", "anyn", "anynn",
+        "allc", "allnc", "anyc", "anync", "cc12", "cc13", "cc14", ""
 ]);
 
 var imm = mkEnum([


### PR DESCRIPTION
It was generating 0 for _all_ conditions for the 'brr' and 'bra' instructions.
This was because the 'pred' variable didn't contain a dot ('.') at the start,
but the lookup table for condition codes did, so the lookup failed.
