### PR TITLE
add BUS_TO_PHYS macro which converts bus address into physical one

### DIFF
--- a/qpu-tutorial/mailbox.h
+++ b/qpu-tutorial/mailbox.h
@@ -45,3 +45,5 @@ void *unmapmem(void *addr, unsigned size);
 unsigned execute_code(int file_desc, unsigned code, unsigned r0, unsigned r1, unsigned r2, unsigned r3, unsigned r4, unsigned r5);
 unsigned execute_qpu(int file_desc, unsigned num_qpus, unsigned control, unsigned noflush, unsigned timeout);
 unsigned qpu_enable(int file_desc, unsigned enable);
+
+#define BUS_TO_PHYS(addr) (((addr)) & ~0xC0000000)

--- a/qpu-tutorial/qpu-01.c
+++ b/qpu-tutorial/qpu-01.c
@@ -34,7 +34,7 @@ int main(int argc, char *argv[]) {
 		goto cleanup;
 	}
 	void *gpu_pointer = (void *)mem_lock(mb, handle);
-	void *arm_pointer = mapmem((unsigned)gpu_pointer+GPU_MEM_MAP, size);
+	void *arm_pointer = mapmem(BUS_TO_PHYS((unsigned)gpu_pointer+GPU_MEM_MAP), size);
 
 	unsigned *p = (unsigned *)arm_pointer;
 

--- a/qpu-tutorial/qpu-02.c
+++ b/qpu-tutorial/qpu-02.c
@@ -38,7 +38,7 @@ int main(int argc, char *argv[]) {
 		goto cleanup;
 	}
 	void *gpu_pointer = (void *)mem_lock(mb, handle);
-	void *arm_pointer = mapmem((unsigned)gpu_pointer+GPU_MEM_MAP, size);
+	void *arm_pointer = mapmem(BUS_TO_PHYS((unsigned)gpu_pointer+GPU_MEM_MAP), size);
 
 	/* Fill result buffer with 0x55 */
 	memset(arm_pointer, 0x55, size);


### PR DESCRIPTION
Hi.

I added BUS_TO_PHYS macro which converts bus address into physical one.
This macro is first seen in https://github.com/raspberrypi/userland/commit/3b81b91c18ff19f97033e146a9f3262ca631f0e9.
By using this macro, qpu-tutorial programs can run correctly on RPi 2.

Please apply these changes to your repo.

Regards,
Terminus-IMRC.